### PR TITLE
Update the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ gem 'rubocop-md'
 
 And then execute:
 
-    $ bundle
+    $ bundle install
 
 Or install it yourself as:
 


### PR DESCRIPTION
### Summary

`bundle` command has been changed to display list of commands with Bundle 2.

```console
% bundle
Bundler version 2.0.0.dev (2018-07-13 commit 0c6048a47)

Bundler commands:

  Primary commands:
    bundle install [OPTIONS]    # Install the current environment to the
    system
    bundle update [OPTIONS]     # Update the current environment
    bundle cache [OPTIONS]      # Locks and then caches all of the gems
    into vendor/cache
    bundle exec [OPTIONS]       # Run the command in context of the
    bundle
    bundle config NAME [VALUE]  # Retrieve or set a configuration value
    bundle help [COMMAND]       # Describe available commands or one specific command
```

I think that it is better to write `bundle install` in the README.md.
The `bundle install` command is compatible with Bundler 1 and Bundler 2.

### Other Infromation

Related PR is bundler/bundler#6068.