### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,10 @@ Layout/EmptyLinesAroundArguments:
 Layout/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space
 
+Naming/FileName:
+  Exclude:
+    - 'lib/rubocop-md.rb'
+
 Metrics/LineLength:
   Max: 100
   Exclude:

--- a/lib/rubocop/markdown/preprocess.rb
+++ b/lib/rubocop/markdown/preprocess.rb
@@ -107,6 +107,7 @@ module RuboCop
       # Return true if it's explicit Ruby and warn_invalid?
       def valid_syntax?(syntax, src)
         return true if ruby?(syntax) && warn_invalid?
+
         !Ripper.sexp(src).nil?
       end
 
@@ -123,6 +124,7 @@ module RuboCop
 
       def comment_lines!(src)
         return if src =~ /\A\n\z/
+
         src.gsub!(/^(.)/m, "##{MARKER}\\1")
       end
     end

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -35,6 +35,7 @@ RuboCop::Runner.prepend(Module.new do
   # NOTE: we should involve preprocessing in RuboCop::CachedData#deserialize_offenses
   def file_offense_cache(file)
     return yield if RuboCop::Markdown.markdown_file?(file)
+
     super
   end
 


### PR DESCRIPTION
This PR fixes the following RuboCop offenses in Travis CI.

https://travis-ci.org/rubocop-hq/rubocop-md/jobs/427134333

```console
$ bundle exec rake
Running RuboCop...
Inspecting 8 files
C.CC....
Offenses:
lib/rubocop-md.rb:1:1:C: Naming/FileName: The name of this source
file (rubocop-md.rb) should use snake_case.
require "rubocop/markdown"
^
lib/rubocop/markdown/preprocess.rb:109:9:C:
Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
        return true if ruby?(syntax) && warn_invalid?
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/markdown/preprocess.rb:125:9:C:
Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
        return if src =~ /\A\n\z/
        ^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/markdown/rubocop_ext.rb:37:5:C:
Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
    return yield if RuboCop::Markdown.markdown_file?(file)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
8 files inspected4 offenses detected
RuboCop failed!
```