### PR TITLE
Fix a RuboCop offense

### DIFF
--- a/lib/rubocop/markdown/preprocess.rb
+++ b/lib/rubocop/markdown/preprocess.rb
@@ -10,7 +10,7 @@ module RuboCop
       # Only recognizes backticks-style code blocks.
       #
       # Try it: http://rubular.com/r/iJaKBkSrrT
-      MD_REGEXP = /^([ \t]*`{3,4})([\w[[:blank:]]]*\n)([\s\S]+?)(^[ \t]*\1[[:blank:]]*\n?)/m
+      MD_REGEXP = /^([ \t]*`{3,4})([\w[[:blank:]]]*\n)([\s\S]+?)(^[ \t]*\1[[:blank:]]*\n?)/m.freeze
 
       MARKER = "<--rubocop/md-->".freeze
 


### PR DESCRIPTION
This PR fixes the following offense.

```console
% bundle exec rake
Running RuboCop...
Inspecting 8 files
.....C..

Offenses:

lib/rubocop/markdown/preprocess.rb:13:19: C: Style/MutableConstant:
Freeze mutable objects assigned to constants.
      MD_REGEXP = /^([ \t]*`{3,4})([\w[[:blank:]]]*\n)([\s\S]+?)(^[\t]*\1[[:blank:]]*\n?)/m
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

8 files inspected, 1 offense detected
RuboCop failed!
```

Refer: https://github.com/rubocop-hq/rubocop/issues/6331