### PR TITLE
Drop Ruby 2.2 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - '*.gemspec'
   DisplayCopNames: true
   StyleGuideCopsOnly: false
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Rails:
   Enabled: false
@@ -20,10 +20,6 @@ Rails:
 Style/Documentation:
   Exclude:
     - 'test/**/*.rb'
-
-# TEMP: wait for the release of https://github.com/rubocop-hq/rubocop/pull/6623
-Style/TrailingCommaInArguments:
-  Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.3.1
       gemfile: Gemfile
-    - rvm: 2.2.0
-      gemfile: Gemfile
   allow_failures:
     - rvm: ruby-head
       gemfile: gemfiles/rubocopmaster.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change log
+
+## master (unreleased)
+
+- Drop Ruby 2.2 support ([@palkan][])
+
+[@palkan]: https://github.com/palkan

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Vladimir Dementyev
+Copyright (c) 2017-2019 Vladimir Dementyev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/rubocop-md.rb
+++ b/lib/rubocop-md.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "rubocop/markdown"

--- a/lib/rubocop/markdown.rb
+++ b/lib/rubocop/markdown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubocop/markdown/version"
 require "pathname"
 

--- a/lib/rubocop/markdown/preprocess.rb
+++ b/lib/rubocop/markdown/preprocess.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "ripper"
 
 module RuboCop
@@ -12,7 +14,7 @@ module RuboCop
       # Try it: http://rubular.com/r/iJaKBkSrrT
       MD_REGEXP = /^([ \t]*`{3,4})([\w[[:blank:]]]*\n)([\s\S]+?)(^[ \t]*\1[[:blank:]]*\n?)/m.freeze
 
-      MARKER = "<--rubocop/md-->".freeze
+      MARKER = "<--rubocop/md-->"
 
       # See https://github.com/github/linguist/blob/v5.3.3/lib/linguist/languages.yml#L3925
       RUBY_TYPES = %w[
@@ -113,13 +115,13 @@ module RuboCop
 
       # Whether to show warning when snippet is not a valid Ruby
       def warn_invalid?
-        config["Markdown"] && config["Markdown"].fetch("WarnInvalid", true)
+        config["Markdown"]&.fetch("WarnInvalid", true)
       end
 
       # Whether to try to detect Ruby by parsing codeblock.
       # If it's set to false we lint only implicitly specified Ruby blocks.
       def autodetect?
-        config["Markdown"] && config["Markdown"].fetch("Autodetect", true)
+        config["Markdown"]&.fetch("Autodetect", true)
       end
 
       def comment_lines!(src)

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Markdown # :nodoc:
     MARKDOWN_EXTENSIONS = %w[.md .markdown].freeze

--- a/lib/rubocop/markdown/version.rb
+++ b/lib/rubocop/markdown/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Markdown
-    VERSION = "0.2.0".freeze
+    VERSION = "0.2.0"
   end
 end

--- a/rubocop-md.gemspec
+++ b/rubocop-md.gemspec
@@ -17,9 +17,19 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
 
+  spec.metadata = {
+    "bug_tracker_uri" => "http://github.com/rubocop-hq/rubocop-md/issues",
+    "changelog_uri" => "https://github.com/rubocop-hq/rubocop-md/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://github.com/rubocop-hq/rubocop-md/blob/master/README.md",
+    "homepage_uri" => "https://github.com/rubocop-hq/rubocop-md",
+    "source_code_uri" => "http://github.com/rubocop-hq/rubocop-md"
+  }
+
+  spec.required_ruby_version = ">= 2.3.0"
+
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", "~> 0.50"
+  spec.add_runtime_dependency "rubocop", "~> 0.60"
 
   spec.add_development_dependency "bundler", ">= 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "open3"
 require "fileutils"

--- a/test/preprocess_test.rb
+++ b/test/preprocess_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 using SquigglyHeredoc

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "rubocop"
 require "rubocop-md"


### PR DESCRIPTION
As RuboCop 0.69.0 also dropped it (and it's reached EOL)