### PR TITLE
CI against Ruby 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ matrix:
       gemfile: gemfiles/rubocopmaster.gemfile
     - rvm: jruby-9.2.8.0
       gemfile: Gemfile
-    - rvm: 2.6
+    - rvm: 2.7
       gemfile: gemfiles/rubocopmaster.gemfile
+    - rvm: 2.7
+      gemfile: Gemfile
     - rvm: 2.6
       gemfile: Gemfile
     - rvm: 2.5


### PR DESCRIPTION
Ruby 2.7.0 has been released and available on Travis CI.

- https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
- http://rubies.travis-ci.org/