### PR TITLE
Fix complex symbol exception

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  NewCops: enable
   Include:
     - 'lib/**/*.rb'
     - 'lib/**/*.rake'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - '*.gemspec'
   DisplayCopNames: true
   StyleGuideCopsOnly: false
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Style/Documentation:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.4.2
       gemfile: Gemfile
-    - rvm: 2.3.1
-      gemfile: Gemfile
   allow_failures:
     - rvm: ruby-head
       gemfile: gemfiles/rubocopmaster.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [#10](https://github.com/rubocop-hq/rubocop-md/pull/10): **Drop Ruby 2.3 support** ([@dominicsayers][])
+
 ## 0.3.2 (2020-03-18)
 
 - [#9](https://github.com/rubocop-hq/rubocop-md/pull/9): Add file extensions for Markdown ([@ybiquitous][])
@@ -18,3 +20,4 @@ Change the default config to use the new cop names for (e.g., `Layout/LineLength
 
 [@palkan]: https://github.com/palkan
 [@ybiquitous]: https://github.com/ybiquitous
+[@dominicsayers]: https://github.com/dominicsayers

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -19,6 +19,7 @@ module RuboCop
 
     class << self
       attr_accessor :config_store
+
       # Merge markdown config into default configuration
       # See https://github.com/backus/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb
       def inject!

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -78,7 +78,7 @@ RuboCop::ProcessedSource.prepend(Module.new do
   def parse(src, *args)
     # only process Markdown files
     src = RuboCop::Markdown::Preprocess.new(path).call(src) if
-      path.nil? || RuboCop::Markdown.markdown_file?(path)
+      path && RuboCop::Markdown.markdown_file?(path)
     super(src, *args)
   end
 end)

--- a/rubocop-md.gemspec
+++ b/rubocop-md.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "http://github.com/rubocop-hq/rubocop-md"
   }
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.require_paths = ["lib"]
 

--- a/test/fixtures/in_flight_parse.rb
+++ b/test/fixtures/in_flight_parse.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+{ 'complex_symbol': 0 }

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -85,6 +85,13 @@ class RuboCop::Markdown::AnalyzeTest < Minitest::Test
     assert_includes res, "file_extensions/09.ronn:"
     assert_includes res, "file_extensions/10.workbook:"
   end
+
+  def test_in_flight_parsing
+    res = run_rubocop("in_flight_parse.rb")
+
+    assert_match %r{Inspecting 1 file}, res
+    assert_match %r{no offenses detected}, res
+  end
 end
 
 class RuboCop::Markdown::AutocorrectTest < Minitest::Test


### PR DESCRIPTION
The cop `Style/HashSyntax` attempts to determine whether a hash has a valid syntax. For complex symbol keys it delegates this to the Ruby parser and calls the parse method on a code snippet with no path context.

By "complex symbol keys" I mean something like this:

    { 'complex_symbol': 0 }

where the key is a symbol but one declared using unusual but valid syntax.

When we run Rubocop, with `rubocop-md` required, on code like this (in a Ruby script rather than embedded in Markdown) we get the following exception:

```bash
An error occurred while Style/HashSyntax cop was inspecting /home/build/Development/dominicsayers/rubocop-hash-syntax-exception/hash_syntax_exception.rb:3:0.
no implicit conversion of nil into String
/home/build/.rvm/gems/ruby-2.6.3/gems/rubocop-md-0.3.2/lib/rubocop/markdown/rubocop_ext.rb:34:in `extname'
/home/build/.rvm/gems/ruby-2.6.3/gems/rubocop-md-0.3.2/lib/rubocop/markdown/rubocop_ext.rb:34:in `markdown_file?'
/home/build/.rvm/gems/ruby-2.6.3/gems/rubocop-md-0.3.2/lib/rubocop/markdown/rubocop_ext.rb:80:in `parse'
```

This PR fixes that exception.

To get the tests to run I have had to make the following changes, which I have minimised as much as possible:

* Drop support for Ruby v2.3 because otherwise core Rubocop complains
* Update the `.rubocop.yml` config to enable new cops by default
* Fix a Rubocop offence in this code that is now detected with recent versions of Rubocop