### PR TITLE
Fix link for contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/palkan/rubocop-md.
+Bug reports and pull requests are welcome on GitHub at https://github.com/rubocop-hq/rubocop-md.
 
 ## License
 


### PR DESCRIPTION
Just a small link I saw pointing to the old repository workspace.