### PR TITLE
UPDATE rubocop version

### DIFF
--- a/lib/rubocop/markdown/preprocess.rb
+++ b/lib/rubocop/markdown/preprocess.rb
@@ -73,8 +73,8 @@ module RuboCop
         walker = Walker.new
 
         parts.each do |part|
-          if walker.code_body?
-            next walker.next! if maybe_ruby?(@syntax) && valid_syntax?(@syntax, part)
+          if walker.code_body? && maybe_ruby?(@syntax) && valid_syntax?(@syntax, part)
+            next walker.next!
           end
 
           if walker.code_attr?

--- a/rubocop-md.gemspec
+++ b/rubocop-md.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", "~> 0.60"
+  spec.add_runtime_dependency "rubocop", ">= 0.60"
 
   spec.add_development_dependency "bundler", ">= 1.15"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
When using rubocop 1.1.0 version, `running rubocop -r "rubocop-md"` raise `Unable to activate rubocop-md-0.3.2, because rubocop-1.1.0 conflicts with rubocop (~> 0.60)` error.


According to [the gem documentation](https://guides.rubygems.org/specification-reference/#required_ruby_version=) I propose to update the version of rubocop in the `rubocop-md.gemspec` file.


All rake test pass, tested on `Fedora 32` with `ruby --version ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]`.